### PR TITLE
Fix titleId parsing regex

### DIFF
--- a/src/db/localSwitchFilesDB.go
+++ b/src/db/localSwitchFilesDB.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	versionRegex = regexp.MustCompile(`\[[vV]?(?P<version>[0-9]{1,10})]`)
-	titleIdRegex = regexp.MustCompile(`\[(?P<titleId>[A-Z,a-z0-9]{16})]`)
+	titleIdRegex = regexp.MustCompile(`\[(?P<titleId>[A-Za-z0-9]{16})]`)
 )
 
 const (

--- a/src/db/localSwitchFilesDB_test.go
+++ b/src/db/localSwitchFilesDB_test.go
@@ -1,0 +1,25 @@
+package db
+
+import "testing"
+
+func TestParseTitleIdFromFileName(t *testing.T) {
+	fileName := "Super Mario [0100000000010000][v0].nsp"
+	titleId, err := parseTitleIdFromFileName(fileName)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if titleId == nil || *titleId != "0100000000010000" {
+		if titleId == nil {
+			t.Fatalf("expected title ID not nil")
+		}
+		t.Fatalf("expected 0100000000010000 got %v", *titleId)
+	}
+}
+
+func TestParseTitleIdFromFileNameInvalid(t *testing.T) {
+	fileName := "Invalid [01000000000100,0][v0].nsp"
+	_, err := parseTitleIdFromFileName(fileName)
+	if err == nil {
+		t.Fatalf("expected error for invalid title id")
+	}
+}


### PR DESCRIPTION
## Summary
- fix regex for title ID parsing to exclude commas
- add test for title ID parsing

## Testing
- `go test ./...` *(fails: could not download Go toolchain)*

