### PR TITLE
Fix deletion order in GUI organize

### DIFF
--- a/src/gui.go
+++ b/src/gui.go
@@ -427,10 +427,10 @@ func (g *GUI) organizeLibrary() {
 		g.state.window.SendMessage(Message{Name: "error", Payload: "the organize options in settings.json are not valid, please check that the template contains file/folder name"}, func(m *astilectron.EventMessage) {})
 		return
 	}
-	process.OrganizeByFolders(folderToScan, g.state.localDB, g.state.switchDB, g)
 	if settings.ReadSettings(g.baseFolder).OrganizeOptions.DeleteOldUpdateFiles {
 		process.DeleteOldUpdates(g.baseFolder, g.state.localDB, g)
 	}
+	process.OrganizeByFolders(folderToScan, g.state.localDB, g.state.switchDB, g)
 }
 
 func (g *GUI) UpdateProgress(curr int, total int, message string) {


### PR DESCRIPTION
## Summary
- remove duplicates before organizing in GUI
- preserve progress updates for deletion

## Testing
- `go test ./...` *(fails: unable to download Go toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_684206117314833395bf43bcb5730e4b