### PR TITLE
Add NCZ support in metadata parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Easily manage your switch game backups
 
 - Cross platform, works on Windows / Mac / Linux
 - GUI and command line interfaces
-- Scan your local switch backup library (NSP/NSZ/XCI)
-- Read titleId/version by decrypting NSP/XCI/NSZ (requires prod.keys)
+- Scan your local switch backup library (NSP/NSZ/NCZ/XCI)
+- Read titleId/version by decrypting NSP/XCI/NSZ/NCZ (requires prod.keys)
 - If no prod.keys present, fallback to read titleId/version by parsing file name (example: `Super Mario Odyssey [0100000000010000][v0].nsp`).
 - Lists missing update files (for games and DLC)
 - Lists missing DLCs

--- a/src/db/localSwitchFilesDB.go
+++ b/src/db/localSwitchFilesDB.go
@@ -205,9 +205,9 @@ func (ldb *LocalSwitchDBManager) processLocalFiles(files []ExtendedFileInfo,
 			}
 		}
 
-		// only handle XCI/XCZ and NSP/NSZ files
+		// only handle XCI/XCZ and NSP/NSZ/NCZ files
 		fileExtension := filepath.Ext(fileName)
-		if !isSplit && fileExtension != ".xci" && fileExtension != ".xcz" && fileExtension != ".nsp" && fileExtension != ".nsz" {
+		if !isSplit && fileExtension != ".xci" && fileExtension != ".xcz" && fileExtension != ".nsp" && fileExtension != ".nsz" && fileExtension != ".ncz" {
 			if _, ok := ignoreFileTypes[fileExtension]; !ok {
 				skipped[file] = SkippedFile{ReasonCode: REASON_UNSUPPORTED_TYPE, ReasonText: "file type is not supported"}
 			}
@@ -324,7 +324,8 @@ func (ldb *LocalSwitchDBManager) getGameMetadata(file ExtendedFileInfo,
 
 		fileName := strings.ToLower(file.FileName)
 		if strings.HasSuffix(fileName, "nsp") ||
-			strings.HasSuffix(fileName, "nsz") {
+			strings.HasSuffix(fileName, "nsz") ||
+			strings.HasSuffix(fileName, "ncz") {
 			metadata, err = switchfs.ReadNspMetadata(filePath)
 			if err != nil {
 				skipped[file] = SkippedFile{ReasonCode: REASON_MALFORMED_FILE, ReasonText: fmt.Sprintf("failed to read NSP [reason: %v]", err)}

--- a/src/db/localSwitchFilesDB_test.go
+++ b/src/db/localSwitchFilesDB_test.go
@@ -23,3 +23,31 @@ func TestParseTitleIdFromFileNameInvalid(t *testing.T) {
 		t.Fatalf("expected error for invalid title id")
 	}
 }
+
+func TestParseTitleIdFromFileNameNCZ(t *testing.T) {
+	fileName := "Super Mario [0100000000010000][v3].ncz"
+	titleId, err := parseTitleIdFromFileName(fileName)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if titleId == nil || *titleId != "0100000000010000" {
+		if titleId == nil {
+			t.Fatalf("expected title ID not nil")
+		}
+		t.Fatalf("expected 0100000000010000 got %v", *titleId)
+	}
+}
+
+func TestParseVersionFromFileNameNCZ(t *testing.T) {
+	fileName := "Super Mario [0100000000010000][v5].ncz"
+	ver, err := parseVersionFromFileName(fileName)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ver == nil || *ver != 5 {
+		if ver == nil {
+			t.Fatalf("expected version not nil")
+		}
+		t.Fatalf("expected version 5 got %v", *ver)
+	}
+}

--- a/src/fileio/splitFileUtil.go
+++ b/src/fileio/splitFileUtil.go
@@ -14,7 +14,7 @@ func ReadSplitFileMetadata(filePath string) (map[string]*switchfs.ContentMetaAtt
 	if err != nil {
 		_, err = readXciHeader(filePath)
 		if err != nil {
-			return nil, errors.New("split file is not an XCI/XCZ or NSP/NSZ")
+			return nil, errors.New("split file is not an XCI/XCZ or NSP/NSZ/NCZ")
 		}
 		isXCI = true
 	}


### PR DESCRIPTION
## Summary
- mention NCZ support in README
- support NCZ extension in split file errors and scanning logic
- parse NCZ filenames via new tests

## Testing
- `go test ./...` *(fails: forbidden - proxy.golang.org)*

------
https://chatgpt.com/codex/tasks/task_e_68525e00852c8333bb8f012f25664b28