### PR TITLE
Add delete_duplicate_files setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ You can customize the folder/file re-naming, as well as turn on/off features, an
   "updates_folder": "", # ex change to Updates to place update folder in a separate folder
   "rename_files": false,
   "delete_empty_folders": false,
+  "delete_duplicate_files": false,
   "delete_old_update_files": false,
   "folder_name_template": "{TITLE_NAME}",
   "switch_safe_file_names": true,

--- a/src/console.go
+++ b/src/console.go
@@ -132,9 +132,9 @@ func (c *Console) Start() {
 	}
 	c.processIssues(localDB, issuesCsvFile)
 
-	if settingsObj.OrganizeOptions.DeleteOldUpdateFiles {
+	if settingsObj.OrganizeOptions.DeleteOldUpdateFiles || settingsObj.OrganizeOptions.DeleteDuplicateFiles {
 		progressBar = progressbar.New(2000)
-		fmt.Printf("\nDeleting old updates\n")
+		fmt.Printf("\nDeleting old/duplicate files\n")
 		process.DeleteOldUpdates(c.baseFolder, localDB, c)
 		progressBar.Finish()
 	}

--- a/src/gui.go
+++ b/src/gui.go
@@ -427,7 +427,8 @@ func (g *GUI) organizeLibrary() {
 		g.state.window.SendMessage(Message{Name: "error", Payload: "the organize options in settings.json are not valid, please check that the template contains file/folder name"}, func(m *astilectron.EventMessage) {})
 		return
 	}
-	if settings.ReadSettings(g.baseFolder).OrganizeOptions.DeleteOldUpdateFiles {
+	opts := settings.ReadSettings(g.baseFolder).OrganizeOptions
+	if opts.DeleteOldUpdateFiles || opts.DeleteDuplicateFiles {
 		process.DeleteOldUpdates(g.baseFolder, g.state.localDB, g)
 	}
 	process.OrganizeByFolders(folderToScan, g.state.localDB, g.state.switchDB, g)

--- a/src/process/organizefolderStructure.go
+++ b/src/process/organizefolderStructure.go
@@ -22,10 +22,14 @@ var (
 )
 
 func DeleteOldUpdates(baseFolder string, localDB *db.LocalSwitchFilesDB, updateProgress db.ProgressUpdater) {
+	opts := settings.ReadSettings(baseFolder).OrganizeOptions
 	i := 0
 	for k, v := range localDB.Skipped {
 		switch v.ReasonCode {
 		case db.REASON_DUPLICATE:
+			if !opts.DeleteDuplicateFiles {
+				continue
+			}
 			fileToRemove := filepath.Join(k.BaseFolder, k.FileName)
 			if updateProgress != nil {
 				updateProgress.UpdateProgress(0, 0, "deleting "+fileToRemove)
@@ -38,6 +42,9 @@ func DeleteOldUpdates(baseFolder string, localDB *db.LocalSwitchFilesDB, updateP
 			}
 			i++
 		case db.REASON_OLD_UPDATE:
+			if !opts.DeleteOldUpdateFiles {
+				continue
+			}
 			fileToRemove := filepath.Join(k.BaseFolder, k.FileName)
 			if updateProgress != nil {
 				updateProgress.UpdateProgress(0, 0, "deleting "+fileToRemove)

--- a/src/resources/app/app.html
+++ b/src/resources/app/app.html
@@ -265,6 +265,12 @@
                 </div>
               </div>
               <div class="form-group row">
+                <label for="createFolders" class="col-sm-2 col-form-label">Delete duplicate files</label>
+                <div class="col-sm-10">
+                  <input type="text" readonly class="form-control-plaintext" id="createFolders" value="{{:settings.organize_options.delete_duplicate_files}}">
+                </div>
+              </div>
+              <div class="form-group row">
                 <label for="createFolders" class="col-sm-2 col-form-label">Delete old update files</label>
                 <div class="col-sm-10">
                   <input type="text" readonly class="form-control-plaintext" id="createFolders" value="{{:settings.organize_options.delete_old_update_files}}">

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -42,6 +42,7 @@ type OrganizeOptions struct {
 	UpdatesFolder              string `json:"updates_folder"`
 	RenameFiles                bool   `json:"rename_files"`
 	DeleteEmptyFolders         bool   `json:"delete_empty_folders"`
+	DeleteDuplicateFiles       bool   `json:"delete_duplicate_files"`
 	DeleteOldUpdateFiles       bool   `json:"delete_old_update_files"`
 	FolderNameTemplate         string `json:"folder_name_template"`
 	SwitchSafeFileNames        bool   `json:"switch_safe_file_names"`
@@ -86,7 +87,7 @@ func ReadSettings(baseFolder string) *AppSettings {
 		return settingsInstance
 	}
 	settingsInstance = &AppSettings{Debug: false, GuiPagingSize: 100, ScanFolders: []string{},
-		OrganizeOptions: OrganizeOptions{SwitchSafeFileNames: true}, Prodkeys: "", IgnoreDLCTitleIds: []string{"01007F600B135007"}}
+		OrganizeOptions: OrganizeOptions{SwitchSafeFileNames: true, DeleteDuplicateFiles: false, DeleteOldUpdateFiles: false}, Prodkeys: "", IgnoreDLCTitleIds: []string{"01007F600B135007"}}
 	if _, err := os.Stat(filepath.Join(baseFolder, SETTINGS_FILENAME)); err == nil {
 		file, err := os.Open(filepath.Join(baseFolder, SETTINGS_FILENAME))
 		if err != nil {
@@ -154,6 +155,7 @@ func saveDefaultSettings(baseFolder string) *AppSettings {
 			FileNameTemplate: fmt.Sprintf("{%v} ({%v})[{%v}][v{%v}]", TEMPLATE_TITLE_NAME, TEMPLATE_DLC_NAME,
 				TEMPLATE_TITLE_ID, TEMPLATE_VERSION),
 			DeleteEmptyFolders:         false,
+			DeleteDuplicateFiles:       false,
 			SwitchSafeFileNames:        true,
 			DeleteOldUpdateFiles:       false,
 			ProcessWhenMissingBaseGame: false,


### PR DESCRIPTION
## Summary
- support deleting duplicate files
- modify cleanup logic to use both deletion settings
- document new setting in README and GUI

## Testing
- `npm test` *(fails: package.json missing)*
- `go test ./...` *(fails: network access required to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_68544cee0b1c8333ba3fe61e71f5e5eb